### PR TITLE
Fix ts config for "paths"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,4 @@ docs/public
 .tern-port
 
 .DS_STORE
+.idea

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,11 @@
             "ESNext",
             "DOM"
         ],
+        "baseUrl": ".",
+        "paths": {
+            "@harlem/core": ["core/src"],
+            "@harlem/utilities": ["packages/utilities/src"],
+        }
     },
     "include": [
         "global.d.ts"


### PR DESCRIPTION
Packages that imports "@harlem/*" will give an error for module not found. Add "paths" to fix that.