### PR TITLE
added a restore option to the storage extension

### DIFF
--- a/docs/src/extensibility/extensions/storage.md
+++ b/docs/src/extensibility/extensions/storage.md
@@ -52,13 +52,15 @@ const {
     mutation,
     startStorageSync,
     stopStorageSync,
-    clearStorage
+    clearStorage,
+    restoreStorage
 } = createStore('example', STATE, {
     extensions: [
         storageExtension({
             type: 'local',
             prefix: 'harlem',
             sync: true,
+            restore: false,
             exclude: [],
             serialiser: state => JSON.stringify(state),
             parser: value => JSON.parse(value)
@@ -77,6 +79,7 @@ The storage extension method accepts an options object with the following proper
 - **type**: `string` - The type of storage interface to use. Acceptable values are `local` or `session`. Default value is `local`.
 - **prefix**: `string` - The prefix to use on the storage key. The storage value will be in the form `${prefix}:${storeName}`. Default value is `harlem`.
 - **sync**: `boolean` - Whether to automatically sync changes from the storage interface back to the store. Default value is `true`.
+- **restore**: `boolean` - Whether to automatically restore the state back from the storage on load. Default is `false`.
 - **exclude**: `string[]` - A list of mutation names to exclude from triggering a storage sync event.
 - **serialiser**: `unknown => string` - A function to serialise the store to string. The default behaviour is `JSON.stringify`.
 - **parser**: `string => unknown` - A function to serialise the storage string to a state structure. The default behaviour is `JSON.parse`.
@@ -88,6 +91,8 @@ The `startStorageSync` and `stopStorageSync` methods can be used to start or sto
 ### Clearing storage
 Use the `clearStorage` method to clear all stored data relating to this store.
 
+### Restoring storage
+Use the `restoreStorage` method to manually restore the state from storage.
 
 ## Considerations
 Please keep the following points in mind when using this extension:

--- a/extensions/storage/README.md
+++ b/extensions/storage/README.md
@@ -40,13 +40,15 @@ const {
     mutation,
     startStorageSync,
     stopStorageSync,
-    clearStorage
+    clearStorage,
+    restoreStorage
 } = createStore('example', STATE, {
     extensions: [
         storageExtension({
             type: 'local',
             prefix: 'harlem',
             sync: true,
+            restore: false,
             exclude: [],
             serialiser: state => JSON.stringify(state),
             parser: value => JSON.parse(value)
@@ -76,6 +78,8 @@ The `startStorageSync` and `stopStorageSync` methods can be used to start or sto
 ### Clearing storage
 Use the `clearStorage` method to clear all stored data relating to this store.
 
+### Restoring storage
+Use the `restoreStorage` method to manually restore the store from storage.
 
 ## Considerations
 Please keep the following points in mind when using this extension:

--- a/extensions/storage/src/index.ts
+++ b/extensions/storage/src/index.ts
@@ -26,6 +26,7 @@ export default function storageExtension<TState extends BaseState>(options?: Par
         type,
         prefix,
         sync,
+        restore,
         exclude,
         serialiser,
         parser,
@@ -33,6 +34,7 @@ export default function storageExtension<TState extends BaseState>(options?: Par
         type: 'local',
         prefix: 'harlem',
         sync: true,
+        restore: false,
         exclude: [],
         serialiser: state => JSON.stringify(state),
         parser: value => JSON.parse(value),
@@ -75,16 +77,25 @@ export default function storageExtension<TState extends BaseState>(options?: Par
             storage.removeItem(storageKey);
         }
 
+        function restoreStorage() {
+            store.write('$storage', SENDER, state => Object.assign(state, parser(<string>storage.getItem(storageKey))));
+        }
+
         store.once(EVENTS.store.destroyed, () => stopStorageSync());
 
         if (sync) {
             startStorageSync();
         }
 
+        if (restore) {
+            restoreStorage();
+        }
+
         return {
             startStorageSync,
             stopStorageSync,
             clearStorage,
+            restoreStorage,
         };
     };
 }

--- a/extensions/storage/src/types.ts
+++ b/extensions/storage/src/types.ts
@@ -9,6 +9,7 @@ export interface Options<TState extends BaseState> {
     type: StorageType;
     prefix: string;
     sync: boolean;
+    restore: boolean;
     exclude: string[];
     serialiser(state: ReadState<TState>): string;
     parser(value: string): TState;


### PR DESCRIPTION
This adresses the issue #43

I added a new option `restore` to the storage extension and created a `restoreStorage` method to restore the state from the storage manually. I set the `restore` option to `false` so existing apps will not break.