### PR TITLE
docs: add instructions if you're using nuxt

### DIFF
--- a/docs/src/guide/introduction/getting-started.md
+++ b/docs/src/guide/introduction/getting-started.md
@@ -24,6 +24,8 @@ npm install @harlem/core
   </CodeGroupItem>
 </CodeGroup>
 
+**Note**: If you're using Nuxt, instead follow the instructions to [install the Nuxt module](https://github.com/nuxt-community/harlem-module) and then resume this guide below, at [Create your first store](#create-your-first-store).
+
 ## Register the Harlem plugin
 
 Register the Harlem plugin with your Vue app instance:


### PR DESCRIPTION
Happy to move this elsewhere or create a dedicated section. The key differences, right now, are that the module installs the dependencies you need to get started (core/ssr/devtools), configures them, and also auto-imports `createStore` where needed.

resolves https://github.com/nuxt-community/harlem-module/issues/2