### PR TITLE
Update compose extension to have callback in set method of useState

### DIFF
--- a/extensions/compose/src/index.ts
+++ b/extensions/compose/src/index.ts
@@ -72,7 +72,8 @@ export default function composeExtension<TState extends BaseState>() {
             }
 
             const getter = () => parent(store.state)[key] as DeepReadonly<TValue>;
-            const setter = (value: TValue) => store.write(name, SENDER, state => {
+            const setter:Setter<TValue> = (valueOrCallback) => store.write(name, SENDER, state => {
+                const value = typeof valueOrCallback === 'function' ? (valueOrCallback as (value: DeepReadonly<TValue>) => TValue)(getter()) : valueOrCallback;
                 parent(state)[key] = value;
             });
 

--- a/extensions/compose/src/types.ts
+++ b/extensions/compose/src/types.ts
@@ -1,7 +1,8 @@
-import {
-    DeepReadonly,
-} from 'vue';
+import { DeepReadonly } from "vue";
 
 export type Accessor<TState, TValue> = (state: TState) => TValue;
 export type Getter<TValue> = () => DeepReadonly<TValue>;
-export type Setter<TValue> = (value: TValue) => void;
+export interface Setter<TValue> {
+  (value: TValue): void;
+  (callback: (value: DeepReadonly<TValue>) => TValue): void;
+}

--- a/extensions/compose/test/compose.test.ts
+++ b/extensions/compose/test/compose.test.ts
@@ -30,6 +30,8 @@ describe('Compose Extension', () => {
         expect(getFirstName()).toBe('');
         setFirstName('John');
         expect(getFirstName()).toBe('John');
+        setFirstName((name) => `${name} Doe`);
+        expect(getFirstName()).toBe('John Doe');
     });
 
     test('Use state with complex value', () => {


### PR DESCRIPTION
Hello, the compose extension is such a cool extension but I think with callback it might have a cleaner usage for setting. It is now also works more like SolidJS's **createSignal** or React's **useState**.

This is a small change and it only enables you to do something like this;
```ts
const [count, setCount] = useState((state) => state.count)

// now you can do this, it will set the count to the returned value
setCount((c) => c + 1);

// you can still use it like
setCount(5);
setCount(count() + 1)
```  