### PR TITLE
Fix action concurrency getting wrong task reference

### DIFF
--- a/extensions/action/src/constants.ts
+++ b/extensions/action/src/constants.ts
@@ -1,17 +1,1 @@
-import {
-    INTERNAL,
-} from '@harlem/core';
-
 export const SENDER = 'extension:action';
-export const STATE_PROP = `${INTERNAL.prefix}actions` as const;
-
-export const MUTATIONS = {
-    init: 'extension:action:init',
-    register: 'extension:action:register',
-    incrementRunCount: 'extension:action:increment-run-count',
-    addInstance: 'extension:action:add-instance',
-    removeInstance: 'extension:action:remove-instance',
-    addError: 'extension:action:add-error',
-    clearErrors: 'extension:action:clear-errors',
-    resetState: 'extension:action:reset-state',
-} as const;

--- a/extensions/action/src/types.ts
+++ b/extensions/action/src/types.ts
@@ -26,9 +26,8 @@ export interface ActionAbortStrategies {
     warn: ActionAbortStrategy;
 }
 
-export interface ActionState<TPayload = unknown, TResult = unknown> {
+export interface ActionState<TPayload = unknown> {
     runCount: number;
-    tasks: Set<Task<TResult>>;
     instances: Map<symbol, TPayload>;
     errors: Map<symbol, unknown>;
 }

--- a/extensions/action/test/actions.test.ts
+++ b/extensions/action/test/actions.test.ts
@@ -202,12 +202,18 @@ describe('Actions Extension', () => {
     });
 
     test('Handles concurrency', async () => {
+        expect.assertions(3);
+
         const {
             action,
         } = instance.store;
 
+        const abortFn = vi.fn();
+
         const concurrentAction = action('concurrent-action', async () => {});
-        const nonConcurrentAction = action('non-concurrent-action', async () => {}, {
+        const nonConcurrentAction = action('non-concurrent-action', async (_, __, ___, onAbort) => {
+            onAbort(abortFn);
+        }, {
             concurrent: false,
         });
 
@@ -234,6 +240,7 @@ describe('Actions Extension', () => {
 
         expect(hasConcurrentFailed).toBe(false);
         expect(hasNonConcurrentFailed).toBe(true);
+        expect(abortFn).toHaveBeenCalled();
     });
 
     test('Handles nested cancellation', async () => {


### PR DESCRIPTION
- Fixed action concurrency failing due to a wrong reference to the running tasks
- Added test case for custom concurrency methods