### PR TITLE
fix(core): handle undefined window in ssr

### DIFF
--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -239,7 +239,7 @@ export const {
 } = createInstance();
 
 // Attach instance creation to the global object
-if (window) {
+if (typeof window !== 'undefined') {
     window.$harlem = {
         createInstance,
     };


### PR DESCRIPTION
This adds a typeof check for window. Otherwise, in SSR, we will get a `window is not defined` error.

Context: https://github.com/nuxt-modules/harlem/pull/226