### PR TITLE
Fix trigger name pattern matching

### DIFF
--- a/packages/utilities/src/match/normalise.ts
+++ b/packages/utilities/src/match/normalise.ts
@@ -18,7 +18,7 @@ export default function normalise(matcher: Matcher): Predicate<string> {
     const patterns = ([] as (string | RegExp)[])
         .concat(matcher)
         .map(pattern => isString(pattern)
-            ? new RegExp(pattern)
+            ? new RegExp(`^${pattern}$`)
             : pattern
         );
 


### PR DESCRIPTION
Fix trigger name matching.

```typescript
const a = action('a', ...);
const ab = action('ab', ...);

onActionSuccess('a', ...); // Triggers on action 'a' and 'ab'
```