### PR TITLE
Add usage trend link

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,9 @@ The official plugins include:
 ## Documentation
 Full documentation for Harlem is available at https://harlemjs.com.
 
+## Usage Trend
+[Usage Trend of Harlem Packages](https://npm-compare.com/@harlem/core,@harlem/plugin-devtools,@harlem/task,@harlem/plugin-ssr,@harlem/extension-trace,@harlem/extension-action,@harlem/extension-storage,@harlem/extension-history,@harlem/extension-lazy,@harlem/extension-transaction,@harlem/extension-compose,@harlem/utilities,@harlem/extension-snapshot,@harlem/extension-reset)
+
 ## Credits
 
 Logo design by [Ethan Roxburgh](https://github.com/ethanroxburgh)


### PR DESCRIPTION
I am writing to request a minor addition to the README file of the Harlem family packages repository.

As an active user to Harlem, I believe it would greatly benefit the community if we could include a link to the npm usage trend for the Harlem family packages. This link will provide users with useful insights such as the usage trend. It will enable them to make informed decisions and stay updated with the latest developments.

I kindly request you to consider this addition. Thanks!